### PR TITLE
Updated JDK dependency to 1.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 install: true
 
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.9.0</version>
+            <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -141,11 +141,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.8.0</version>
                 <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
                     during build -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>
-                <version>2.0.1</version>
+                <version>1.0-beta-1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </developers>
 
     <properties>
-        <jdk.version>1.11</jdk.version>
+        <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.apiVersion>6.7.1</sonar.apiVersion>
         <slf4j.version>1.7.25</slf4j.version>
@@ -143,8 +143,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,17 @@
             <artifactId>jaxb-impl</artifactId>
             <version>2.3.1</version>
         </dependency>
+        <!-- runtime dependency -->
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
+        </dependency>
         <dependency>
             <!-- packaged with the plugin -->
             <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </developers>
 
     <properties>
-        <jdk.version>1.8</jdk.version>
+        <jdk.version>1.11</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.apiVersion>6.7.1</sonar.apiVersion>
         <slf4j.version>1.7.25</slf4j.version>
@@ -68,6 +68,21 @@
             <artifactId>sonar-plugin-api</artifactId>
             <version>${sonar.apiVersion}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <!-- packaged with the plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.6.201602180812</version>
+                <version>0.8.4</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -152,7 +152,7 @@
                     during build -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>
-                <version>1.0-beta-1</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/test/java/fr/cnes/sonar/plugins/icode/check/ICodeSensorTest.java
+++ b/src/test/java/fr/cnes/sonar/plugins/icode/check/ICodeSensorTest.java
@@ -169,7 +169,7 @@ public class ICodeSensorTest {
 
         final int value = sensor.runICode("java -version");
         
-        Assert.assertEquals(1, value);
+        Assert.assertEquals(0, value);
     }
 
     @Test

--- a/src/test/java/fr/cnes/sonar/plugins/icode/check/ICodeSensorTest.java
+++ b/src/test/java/fr/cnes/sonar/plugins/icode/check/ICodeSensorTest.java
@@ -167,7 +167,7 @@ public class ICodeSensorTest {
     public void test_run_a_command() throws IOException, InterruptedException {
         final ICodeSensor sensor = new ICodeSensor();
 
-        final int value = sensor.runICode("java --version");
+        final int value = sensor.runICode("java -version");
         
         Assert.assertEquals(1, value);
     }


### PR DESCRIPTION
### Fixes :
- Plugin could not be loaded by SonarQube 7.9 LTS. Since SonarQube requires Java 11, the dependencies of this plugin has been updated accordingly.
- See also: https://community.sonarsource.com/t/plugin-incompatibility-with-jdk-e-g-sonar-i-code-cnes-plugin/11752

### Changes proposed :
- Added JAXB module dependencies.
- Updated JDK dependency to 1.11.
- Updated dependency versions to be able to work with JDK 1.11